### PR TITLE
Include sys/types.h in lexer.h

### DIFF
--- a/src/lexer.h
+++ b/src/lexer.h
@@ -9,6 +9,7 @@
 #define __LUNA_LEXER__
 
 #include <stdio.h>
+#include <sys/types.h>
 #include <sys/stat.h>
 #include "token.h"
 


### PR DESCRIPTION
This fixes complaints about `off_t` not being defined on ArchLinux 64bit, GCC 4.7.2.
