### PR TITLE
lexer: fix int default to float

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -233,6 +233,7 @@ scan_number(luna_lexer_t *self, int c) {
   } while (isdigit(c = next) || '_' == c || '.' == c);
   undo;
   self->tok.value.as_int = n;
+  return 1;
 
   // [0-9_]+
 
@@ -248,7 +249,7 @@ scan_number(luna_lexer_t *self, int c) {
     undo;
     self->tok.value.as_float = (float) n / e;
   }
-
+  
   return 1;
 }
 


### PR DESCRIPTION
In current version:

``` lua
luna> 1
(float 1.000000)
```

I think it should be 

``` lua
luna> 1
(int 1)
```

Then I do this fixup :p
