### PR TITLE
Could not build Luna in Ubuntu 64bit. Fixed by adding -lm flag in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ifdef SystemRoot
 endif
 
 $(OUT): $(OBJ)
-	$(CC) $^ $(LDFLAGS) -o $@
+	$(CC) $^ $(LDFLAGS) -lm -o $@
 
 %.o: %.c
 	@$(CC) -c $(CFLAGS) $< -o $@


### PR DESCRIPTION
Couldn't build Luna because of these errors.
```bash
Luna/src/lexer.c:262: undefined reference to `pow'
Luna/src/lexer.c:264: undefined reference to `pow'
```
Fixed by adding ``-lm`` flag in Makefile.