### PR TITLE
add ferror to file_read

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -58,7 +58,7 @@ read_until_eof(FILE *stream) {
   assert(str);
   
   // read
-  while (!feof(stream)) {
+  while (!feof(stream) &&  !ferror(stream)) {
     size_t n = fread(buf, 1, 1024, stream);
     len += strlen(buf);
     str = realloc(str, len);

--- a/src/utils.c
+++ b/src/utils.c
@@ -58,7 +58,7 @@ read_until_eof(FILE *stream) {
   assert(str);
   
   // read
-  while (!feof(stream) &&  !ferror(stream)) {
+  while (!feof(stream) && !ferror(stream)) {
     size_t n = fread(buf, 1, 1024, stream);
     len += strlen(buf);
     str = realloc(str, len);


### PR DESCRIPTION
As the manual say: "callers must use feof(3) and ferror(3) to determine which occurred." Only use `feof` may enters the loop one more time.