### PR TITLE
fix until.c 

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -58,7 +58,7 @@ read_until_eof(FILE *stream) {
   assert(str);
   
   // read
-  while (!feof(stream) &&  !ferror(stream)) {
+  while (!feof(stream) && !ferror(stream)) {
     size_t n = fread(buf, 1, 1024, stream);
     len += strlen(buf);
     str = realloc(str, len);


### PR DESCRIPTION
fix function`read_until_eof`, change `strcat` to `strncat`. Cause each time read more the 1024, `buf` may contains characters unexpected.